### PR TITLE
Fix compatibility with v02-06 release of LCIO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,28 @@ ELSE()
     # include directories
     INCLUDE_DIRECTORIES( ${XERCES_INCLUDE_DIR} ${LCIO_INCLUDE_DIRS} ${Geant4_INCLUDE_DIRS} ${GDML_INCLUDE_DIR} ${LCDD_INCLUDE_DIR} ${HEPPDT_INCLUDE_DIR} )
 
+    # check for LCStdHepRdrNew class in LCIO
+    IF ( EXISTS "${LCIO_INCLUDE_DIRS}/UTIL/LCStdHepRdrNew.h" )
+        ADD_DEFINITIONS( -DHAVE_STDHEPRDRNEW_H )
+    ENDIF()
+
+    # check if MCParticle implementation has endpoint momentum 
+    SET( CMAKE_REQUIRED_INCLUDES ${LCIO_INCLUDE_DIRS} )
+    INCLUDE(CheckCXXSourceCompiles)
+    CHECK_CXX_SOURCE_COMPILES(
+        "
+        #include \"EVENT/MCParticle.h\"
+        int main() {
+            EVENT::MCParticle* p;
+            p->getMomentumAtEndpoint();
+            return 0;
+        }
+        " MCPARTICLE_HAS_MOMENTUMATENDPOINT
+    )
+    IF ( MCPARTICLE_HAS_MOMENTUMATENDPOINT )
+        ADD_DEFINITIONS( -DMCPARTICLE_HAS_MOMENTUMATENDPOINT )
+    ENDIF()
+
     # libraries
     TARGET_LINK_LIBRARIES( slic ${XERCES_LIBRARY} ${Geant4_LIBRARIES} ${GDML_LIBRARY} ${LCDD_LIBRARY} ${HEPPDT_LIBRARIES} ${LCIO_LIBRARIES} slicPlugins )
 

--- a/cmake/InstallGDML.cmake
+++ b/cmake/InstallGDML.cmake
@@ -1,5 +1,5 @@
-IF( NOT GDML_VERSION )
-    SET( GDML_VERSION "master" )
+IF( NOT GDML_TAG )
+    SET( GDML_TAG "master" )
 ENDIF()
 
 EXTERNALPROJECT_ADD(
@@ -9,7 +9,7 @@ EXTERNALPROJECT_ADD(
     DEPENDS XERCES Geant4 
 
     GIT_REPOSITORY "https://github.com/slaclab/gdml"
-    GIT_TAG ${GDML_VERSION}
+    GIT_TAG ${GDML_TAG}
     
     UPDATE_COMMAND ""
     PATCH_COMMAND ""

--- a/cmake/InstallGeant4.cmake
+++ b/cmake/InstallGeant4.cmake
@@ -1,8 +1,8 @@
-IF( NOT Geant4_VERSION )
-    SET( Geant4_VERSION "v10.3.1" )
+IF( NOT Geant4_TAG )
+    SET( Geant4_TAG "v10.3.1" )
 ENDIF()
 
-IF ( Geant4_VERSION EQUAL "master" )
+IF ( Geant4_TAG EQUAL "master" )
     MESSAGE( FATAL_ERROR "Installing Geant4 from github master is not allowed." )
 ENDIF()
 
@@ -14,7 +14,7 @@ EXTERNALPROJECT_ADD(
     Geant4
 
     GIT_REPOSITORY "https://github.com/Geant4/geant4"
-    GIT_TAG ${GEANT4_VERSION}
+    GIT_TAG ${GEANT4_TAG}
     
     UPDATE_COMMAND ""
     PATCH_COMMAND ""
@@ -26,5 +26,5 @@ EXTERNALPROJECT_ADD(
     BUILD_COMMAND make -j4
 )
 
-STRING( REPLACE "v" "" Geant4_VERSION_NUMBER ${Geant4_VERSION} )
+STRING( REPLACE "v" "" Geant4_VERSION_NUMBER ${Geant4_TAG} )
 SET( Geant4_DIR ${DEPENDENCY_INSTALL_DIR}/geant4/lib64/Geant4-${Geant4_VERSION_NUMBER} CACHE PATH "Geant4 install dir" FORCE )

--- a/cmake/InstallLCDD.cmake
+++ b/cmake/InstallLCDD.cmake
@@ -1,5 +1,5 @@
-IF( NOT LCDD_VERSION )
-    SET( LCDD_VERSION "master" )
+IF( NOT LCDD_TAG )
+    SET( LCDD_TAG "master" )
 ENDIF()
 
 EXTERNALPROJECT_ADD(
@@ -8,7 +8,7 @@ EXTERNALPROJECT_ADD(
     DEPENDS XERCES Geant4 GDML
 
     GIT_REPOSITORY "https://github.com/slaclab/lcdd"
-    GIT_TAG ${LCDD_VERSION}
+    GIT_TAG ${LCDD_TAG}
     
     UPDATE_COMMAND ""
     PATCH_COMMAND ""

--- a/cmake/InstallLCIO.cmake
+++ b/cmake/InstallLCIO.cmake
@@ -1,12 +1,12 @@
-IF( NOT LCIO_VERSION )
-    SET( LCIO_VERSION "master" )
+IF( NOT LCIO_TAG )
+    SET( LCIO_TAG "master" )
 ENDIF()
 
 EXTERNALPROJECT_ADD(
     LCIO
 
     GIT_REPOSITORY "https://github.com/iLCSoft/LCIO"
-    GIT_TAG ${LCIO_VERSION}
+    GIT_TAG ${LCIO_TAG}
     
     UPDATE_COMMAND ""
     PATCH_COMMAND ""

--- a/include/StdHepGenerator.hh
+++ b/include/StdHepGenerator.hh
@@ -5,7 +5,11 @@
 #include "MCParticleManager.hh"
 
 // LCIO
+#if HAVE_LCSTDHEPRDRNEW_H
 #include "UTIL/LCStdHepRdrNew.h"
+#else
+#include "UTIL/LCStdHepRdr.h"
+#endif
 #include "EVENT/MCParticle.h"
 #include "IMPL/LCCollectionVec.h"
 
@@ -16,7 +20,12 @@
 // STL
 #include <set>
 
+#if HAVE_LCSTDHEPRDRNEW_H
 using UTIL::LCStdHepRdrNew;
+#else
+using UTIL::LCStdHepRdr;
+#endif
+
 using EVENT::MCParticle;
 using EVENT::LCCollection;
 using IMPL::LCCollectionVec;
@@ -60,7 +69,11 @@ public:
     LCCollectionVec* getCurrentParticleCollection();
 
 private:
+#if HAVE_LCSTDHEPRDRNEW_H
     LCStdHepRdrNew* _reader;
+#else
+    LCStdHepRdr* _reader;
+#endif
     LCCollectionVec* _particles;
 };
 

--- a/src/StdHepGenerator.cc
+++ b/src/StdHepGenerator.cc
@@ -9,7 +9,6 @@
 // Geant4
 #include "G4SystemOfUnits.hh"
 
-using UTIL::LCStdHepRdrNew;
 using EVENT::MCParticle;
 using EVENT::LCCollection;
 using IMPL::MCParticleImpl;
@@ -18,7 +17,11 @@ namespace slic {
 
 StdHepGenerator::StdHepGenerator(G4String eventFile)
     : _particles(0) {
+#if HAVE_LCSTDHEPRDRNEW_H
     _reader = new LCStdHepRdrNew(eventFile.data());
+#else
+    _reader = new LCStdHepRdr(eventFile.data());
+#endif
 }
 
 StdHepGenerator::~StdHepGenerator() {

--- a/src/TrackSummary.cc
+++ b/src/TrackSummary.cc
@@ -227,11 +227,13 @@ void TrackSummary::buildMCParticle() {
     _mcparticle->setTime(_globalTime);
 
     /* Set momentum at endpoint. */
+#ifdef MCPARTICLE_HAS_MOMENTUMATENDPOINT
     float momentumAtEndpoint[3];
     momentumAtEndpoint[0] = _momentumAtEndpoint(0) / GeV;
     momentumAtEndpoint[1] = _momentumAtEndpoint(1) / GeV;
     momentumAtEndpoint[2] = _momentumAtEndpoint(2) / GeV;
     _mcparticle->setMomentumAtEndpoint(momentumAtEndpoint);
+#endif
 
     /* Set up to date. */
     _mcParticleIsUpToDate = true;


### PR DESCRIPTION
- Add checks in CMake config for compatibility with LCIO v02-06

- Use `${PACKAGE_NAME}_TAG` variable for specifying a github tag for an external dep so as not to interfere with the `find_package` macro 