### PR TITLE
Added protection against recursive MCParticleManager::createPrimary()…

### DIFF
--- a/include/MCParticleManager.hh
+++ b/include/MCParticleManager.hh
@@ -105,6 +105,7 @@ public:
         _primaryMap.clear();
         _mcpMap.clear();
         _mcpVec = 0;
+	_recursionBlockSet.clear();
     }
 
     /**
@@ -199,6 +200,9 @@ private:
      * Map of MCParticle to track ID.
      */
     TrackIDMap _trackIDMap;
+
+    // Set to keep track of particles whose daughters have already been added by createPrimary()
+    std::set<MCParticle *> _recursionBlockSet;
 
     LCCollectionVec* _inputVec;
 

--- a/src/MCParticleManager.cc
+++ b/src/MCParticleManager.cc
@@ -262,19 +262,23 @@ std::set<G4PrimaryParticle*> MCParticleManager::createPrimary(G4PrimaryParticle*
 #endif
     }
 
-    for (int i = 0; i < mcp->getDaughters().size(); i++) {
+    if (_recursionBlockSet.count(mcp) == 0) {
+	_recursionBlockSet.insert(mcp);
+
+	for (int i = 0; i < mcp->getDaughters().size(); i++) {
 #ifdef SLIC_LOG
-        log() << LOG::debug << "recursively creating primaries for " << indexOf(primary) << LOG::done;
+	    log() << LOG::debug << "recursively creating primaries for " << indexOf(primary) << LOG::done;
 #endif
-        std::set<G4PrimaryParticle*> daughters = createPrimary(primary, mcp->getDaughters()[i]);
+	    std::set<G4PrimaryParticle*> daughters = createPrimary(primary, mcp->getDaughters()[i]);
 #ifdef SLIC_LOG
-        log() << LOG::debug << "created " << daughters.size() << " daughter primaries" << LOG::done;
+	    log() << LOG::debug << "created " << daughters.size() << " daughter primaries" << LOG::done;
 #endif
 
-        if (daughters.size() > 0) {
-            primaries.insert(daughters.begin(), daughters.end());
-        }
+	    if (daughters.size() > 0)
+		primaries.insert(daughters.begin(), daughters.end());
+	}
     }
+
 #ifdef SLIC_LOG
         log().getOutputStream().flush();
 #endif


### PR DESCRIPTION
… from getting out of control

Added after observation of infinite or very large loop in createPrimary() for very large events from Pythia8.