### PR TITLE
Fix casting error.

### DIFF
--- a/src/LcioHitsCollectionBuilder.cc
+++ b/src/LcioHitsCollectionBuilder.cc
@@ -225,7 +225,7 @@ IMPL::SimCalorimeterHitImpl* LcioHitsCollectionBuilder::createHit(CalorimeterHit
 
     // position
     const G4ThreeVector hitPos = calHit->getPosition();
-    float pos[3] = { hitPos.x(), hitPos.y(), hitPos.z() };
+    float pos[3] = { (float)hitPos.x(), (float)hitPos.y(), (float)hitPos.z() };
     simCalHit->setPosition(pos);
 
     //  copy Mcp contrib info; energy is also incremented by contrib addition


### PR DESCRIPTION
This fixes the error when compiling with clang++ version 9.0.0:

LcioHitsCollectionBuilder.cc:228:22: error: non-constant-expression cannot be narrowed from type 'double' to 'float' in initializer list
      [-Wc++11-narrowing]
    float pos[3] = { hitPos.x(), hitPos.y(), hitPos.z() };

