### PR TITLE
Add a TARGET_LINK_LIBRARIES so that the slicPlugins are properly link…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ ELSE()
     # build user plugin library
     FILE( GLOB_RECURSE plugin_sources ${PROJECT_SOURCE_DIR}/plugins/*.cc )
     ADD_LIBRARY( slicPlugins SHARED ${plugin_sources} )
+    TARGET_LINK_LIBRARIES(slicPlugins ${Geant4_LIBRARIES} )
     INSTALL( TARGETS slicPlugins DESTINATION ${CMAKE_INSTALL_PREFIX}/lib )
 
     # set executable target


### PR DESCRIPTION
Simple fix to get slic to compile smoothly on systems that require a complete link list for dynamically loaded libraries (um, macOS)
