### PR TITLE
Modify the behavior for Macs to properly add the rpath to the executable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,29 @@ if(CMAKE_CXX_COMPILER_VERSION LESS 4.8)
     message(FATAL_ERROR "The GCC version is too old (at least 4.8 is required).")
 ENDIF()
 
+if(APPLE)
+    # use, i.e. don't skip the full RPATH for the build tree
+    SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+
+    # when building, don't use the install RPATH already
+    # (but later on when installing)
+    SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+    SET(CMAKE_INSTALL_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+
+    # add the automatically determined parts of the RPATH
+    # which point to directories outside the build tree to the install RPATH
+    SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+    # the RPATH to be used when installing, but only if it's not a system directory
+    LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}" isSystemDir)
+    IF("${isSystemDir}" STREQUAL "-1")
+        SET(CMAKE_INSTALL_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+        message("CMAKE_INSTALL_RPATH set to ${CMAKE_INSTALL_RPATH} ")
+
+    ENDIF("${isSystemDir}" STREQUAL "-1")
+endif(APPLE)
+
 # add path containing CMake macros for this project
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,22 +17,22 @@ ENDIF()
 
 if(APPLE)
     # use, i.e. don't skip the full RPATH for the build tree
-    SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+    set(CMAKE_SKIP_BUILD_RPATH  FALSE)
 
     # when building, don't use the install RPATH already
     # (but later on when installing)
-    SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 
-    SET(CMAKE_INSTALL_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+    set(CMAKE_INSTALL_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 
     # add the automatically determined parts of the RPATH
     # which point to directories outside the build tree to the install RPATH
-    SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
     # the RPATH to be used when installing, but only if it's not a system directory
-    LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}" isSystemDir)
+    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}" isSystemDir)
     IF("${isSystemDir}" STREQUAL "-1")
-        SET(CMAKE_INSTALL_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+        set(CMAKE_INSTALL_RPATH "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
         message("CMAKE_INSTALL_RPATH set to ${CMAKE_INSTALL_RPATH} ")
 
     ENDIF("${isSystemDir}" STREQUAL "-1")


### PR DESCRIPTION
That way the code will just run without having the monkey with the LD_LIBRARY_PATH and its friends.

This issue is specifically for Mac computers, which have a nice way of dealing with library paths that only work if you tell cmake to do so correctly.

The issue is especially important if Geant4 was compiled with Qt5, which will add the Qt5 libraries into the executable as:
```Load command 38
          cmd LC_LOAD_DYLIB
      cmdsize 72
         name @rpath/QtOpenGL.framework/Versions/5/QtOpenGL (offset 24)
   time stamp 2 Wed Dec 31 19:00:02 1969
      current version 5.14.2
```
This means that if you try to find Qt by setting DYLD_LIBRARY_PATH, you will need to set the path to 
<path_to_qt_install>/lib/QtOpenGL.framework/Versions/5:<path_to_qt_install>/lib/QtPrintSupport.framework/Versions/5
etc, one *for each* Qt library that was included. 

With the fix, the LC_RPATH sections are kept when running "make install", so that the executable still works after installation.