### PR TITLE
Remove excessive print outs.

### DIFF
--- a/include/EventAction.hh
+++ b/include/EventAction.hh
@@ -78,7 +78,7 @@ class EventAction: public G4UserEventAction, public Module, public PluginManager
          * Print the end of event message.
          * @param[in] anEvent The Geant4 event.
          */
-        void printEndEventMessage(const G4Event *anEvent);
+        //void printEndEventMessage(const G4Event *anEvent);
 
     private:
 

--- a/include/RunAction.hh
+++ b/include/RunAction.hh
@@ -59,13 +59,13 @@ class RunAction: public G4UserRunAction, public Module, public PluginManagerAcce
          * Print the beginning of run message.
          * @param[in] aRun The G4Run that is starting.
          */
-        void printBeginOfRunMessage(const G4Run *aRun);
+        //void printBeginOfRunMessage(const G4Run *aRun);
 
         /**
          * Print the end of run message.
          * @param[in] aRun The G4Run that is ending.
          */
-        void printEndOfRunMessage(const G4Run *aRun);
+        //void printEndOfRunMessage(const G4Run *aRun);
 
     private:
 

--- a/src/EventAction.cc
+++ b/src/EventAction.cc
@@ -59,12 +59,13 @@ void EventAction::EndOfEventAction(const G4Event *anEvent) {
     stopEventTimer();
 
     /* Print the end event message. */
-    printEndEventMessage(anEvent);
+    //printEndEventMessage(anEvent);
 }
 
+/*
 void EventAction::printEndEventMessage(const G4Event *anEvent) {
-    log() << LOG::okay << ">>>> EndEvent <" + StringUtil::toString(anEvent->GetEventID()) + ">" << LOG::endl << LOG::done;
-}
+    //log() << LOG::okay << ">>>> EndEvent <" + StringUtil::toString(anEvent->GetEventID()) + ">" << LOG::endl << LOG::done;
+}*/
 
 EventAction* EventAction::getEventAction() {
     const EventAction* ea = static_cast<const EventAction*>(G4RunManager::GetRunManager()->GetUserEventAction());

--- a/src/LcioHitsCollectionBuilder.cc
+++ b/src/LcioHitsCollectionBuilder.cc
@@ -103,7 +103,7 @@ void LcioHitsCollectionBuilder::createHitCollections() {
                         m_currentLCEvent->addCollection(collVec, HC->GetName());
 
 #ifdef SLIC_LOG
-                        log() << LOG::always << HC->GetName() << " has " << collVec->size() << " hits" << LOG::done;
+                        //log() << LOG::always << HC->GetName() << " has " << collVec->size() << " hits" << LOG::done;
 #endif
                     }
                 }

--- a/src/PrimaryGeneratorAction.cc
+++ b/src/PrimaryGeneratorAction.cc
@@ -27,7 +27,7 @@ PrimaryGeneratorAction::~PrimaryGeneratorAction() {
 void PrimaryGeneratorAction::GeneratePrimaries(G4Event *anEvent) {
 
     /* Print begin of event message. */
-    printBeginEventMessage(anEvent);
+    //printBeginEventMessage(anEvent);
 
     /* Reset the TrackManager's state from previous event. */
     TrackManager::instance()->reset();
@@ -55,7 +55,7 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event *anEvent) {
     m_pluginManager->generatePrimary(anEvent);
 }
 
-void PrimaryGeneratorAction::printBeginEventMessage(G4Event* anEvent) {
+/*void PrimaryGeneratorAction::printBeginEventMessage(G4Event* anEvent) {
     log() << LOG::okay << ">>>> BeginEvent <" << StringUtil::toString(anEvent->GetEventID()) << ">" << LOG::done;
-}
+}*/
 }

--- a/src/RunAction.cc
+++ b/src/RunAction.cc
@@ -26,7 +26,7 @@ void RunAction::BeginOfRunAction(const G4Run *aRun) {
 
     // Print the run start message.
 #ifdef SLIC_LOG
-    printBeginOfRunMessage( aRun );
+    //printBeginOfRunMessage( aRun );
 #endif
 
     // Execute LcioManager's beginRun action.
@@ -56,7 +56,7 @@ void RunAction::EndOfRunAction(const G4Run *run) {
 
     // end message
 #ifdef SLIC_LOG
-    printEndOfRunMessage( run );
+    //printEndOfRunMessage( run );
 #endif
 }
 
@@ -77,11 +77,12 @@ void RunAction::stopRunTimer() {
 #endif
 }
 
+/*
 void RunAction::printBeginOfRunMessage(const G4Run* aRun) {
     log() << LOG::okay << ">>>> BeginRun <" << aRun->GetRunID() << ">" << LOG::done;
 }
 
 void RunAction::printEndOfRunMessage(const G4Run* aRun) {
     log() << LOG::okay << ">>>> EndRun <" << aRun->GetRunID() << ">" << LOG::done;
-}
+}*/
 }

--- a/src/TrackManager.cc
+++ b/src/TrackManager.cc
@@ -70,7 +70,7 @@ void TrackManager::saveTrackSummaries(const G4Event* anEvent, LCEvent* lcEvent) 
 
     /* Save TrackSummary objects to LCIO collection. */
 #ifdef SLIC_LOG
-    log() << LOG::okay << "TrackManager processing " << _trackSummaries->size() << " TrackSummary objects." << LOG::done;
+    /*log() << LOG::okay << "TrackManager processing " << _trackSummaries->size() << " TrackSummary objects." << LOG::done;*/
 #endif
     size_t l;
     TrackSummary* trackSummary;
@@ -116,7 +116,7 @@ void TrackManager::saveTrackSummaries(const G4Event* anEvent, LCEvent* lcEvent) 
     lcEvent->addCollection((LCCollection*) mcpVec, "MCParticle");
 
 #ifdef SLIC_LOG
-    log() << LOG::always << "Saved " << mcpVec->getNumberOfElements() << " MCParticles." << LOG::done;
+    //log() << LOG::always << "Saved " << mcpVec->getNumberOfElements() << " MCParticles." << LOG::done;
 #endif
 
 }


### PR DESCRIPTION
This removes the excessive print outs that aren't being handled correctly.  For now, everything is commented it out.  A future PR will improve the logger and add these print outs back. 