### PR TITLE
updated Doxyfile, Doxygen main page adjustment, comment style update

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1077,7 +1077,7 @@ SOURCE_BROWSER         = YES
 # classes and enums directly into the documentation.
 # The default value is: NO.
 
-INLINE_SOURCES         = YES
+INLINE_SOURCES         = NO
 
 # Setting the STRIP_CODE_COMMENTS tag to YES will instruct doxygen to hide any
 # special comment blocks from generated source code fragments. Normal C, C++ and

--- a/include/CommandLineProcessor.hh
+++ b/include/CommandLineProcessor.hh
@@ -163,13 +163,13 @@ class CommandLineProcessor: public Module, public Singleton<CommandLineProcessor
 
     private:
 
-        // A vector of options with their arguments.
+        /** A vector of options with their arguments. */
         CommandLineArguments m_commandline;
 
-        // A list of Geant4 macro commands filled by processing the command line arguments.
+        /** A list of Geant4 macro commands filled by processing the command line arguments. */
         CommandQueue m_g4q;
 
-        // The list of valid options and their associated meta-data.
+        /** The list of valid options and their associated meta-data. */
         OptionsList m_cmds;
 
         // Flags to be set by the process function.
@@ -177,7 +177,7 @@ class CommandLineProcessor: public Module, public Singleton<CommandLineProcessor
         int m_interactive_flag;
         int m_version_flag;
 
-        // The getopt options string, which is created automatically.
+        /** The getopt options string, which is created automatically. */
         std::string m_getoptOptions;
 };
 }

--- a/include/EventSourceManager.hh
+++ b/include/EventSourceManager.hh
@@ -300,13 +300,13 @@ class EventSourceManager: public Module, public Singleton<EventSourceManager> {
 
     private:
 
-        // generator messenger
+        /** generator messenger */
         GeneratorMessenger* m_messenger;
 
-        // current event source
+        /** current event source */
         EventSource* m_currentEventSource;
 
-        // ParticleGun source.  Always enabled.
+        /** ParticleGun source.  Always enabled. */
         EventSource* m_particleGunSource;
 
         // filename
@@ -314,13 +314,13 @@ class EventSourceManager: public Module, public Singleton<EventSourceManager> {
         bool m_fileIsSet;
         bool m_newFilename;
 
-        // num events generated on current generator
+        /** num events generated on current generator */
         int m_ngen;
 
-        // num events to skip
+        /** num events to skip */
         unsigned int m_nskip;
 
-        // need to setup a new source new run?
+        /** need to setup a new source new run? */
         bool m_newSource;
 
         // gen strings
@@ -331,13 +331,13 @@ class EventSourceManager: public Module, public Singleton<EventSourceManager> {
         static std::string LHE;
         static std::string UNKNOWN;
 
-        // source type
+        /** source type */
         ESourceType m_sourceType;
 
-        // Lorentz transformation angle which will be applied to event.
+        /** Lorentz transformation angle which will be applied to event. */
         G4double m_lorentzTransformationAngle;
 
-        // Parameter which will be used to smear vertex Z position.
+        /** Parameter which will be used to smear vertex Z position. */
         G4double m_zSmearingParam;
 
         G4bool m_enablePrintEvent;

--- a/include/EventSourceWithInputFile.hh
+++ b/include/EventSourceWithInputFile.hh
@@ -97,7 +97,7 @@ class EventSourceWithInputFile: public EventSource {
 
     protected:
 
-        // name of input file
+        /** name of input file */
         std::string m_filename;
 
         // state vars

--- a/include/LcioHitsCollectionBuilder.hh
+++ b/include/LcioHitsCollectionBuilder.hh
@@ -179,17 +179,17 @@ class LcioHitsCollectionBuilder: public Module {
 
     private:
 
-        // current Lcio event
+        /** current Lcio event */
         EVENT::LCEvent* m_currentLCEvent;
 
-        // current G4 event
+        /** current G4 event */
         const G4Event* m_currentG4Event;
 
-        // default flags
+        /** default flags */
         IMPL::LCFlagImpl m_trkCollFlag;
         IMPL::LCFlagImpl m_calCollFlag;
 
-        // store momentum
+        /** store momentum */
         bool m_storeMomentum;
 };
 }

--- a/include/LcioManager.hh
+++ b/include/LcioManager.hh
@@ -285,32 +285,33 @@ class LcioManager: public Module, public Singleton<LcioManager> {
 
     private:
 
-        // writer
+        /** writer */
         IO::LCWriter* m_writer;
 
-        // run header
+        /** run header */
         IMPL::LCRunHeaderImpl* m_runHdr;
 
-        // file info
+        /** file info -- filename */
         std::string m_filename;
+        /** file info -- path */
         std::string m_path;
 
         // event generator from MCP Coll
         //LcioPrimaryGenerator* m_eventGenerator;
 
-        // creation of HCs
+        /** creation of HCs */
         LcioHitsCollectionBuilder* m_HCBuilder;
 
-        // current LCEvent
+        /** current LCEvent */
         IMPL::LCEventImpl* m_currentLCEvent;
 
         // messenger
         LcioMessenger* m_messenger;
 
-        // action when file exists
+        /** action when file exists */
         EFileExistsAction m_fileExistsAction;
 
-        // starting run number
+        /** starting run number */
         int m_runNumber;
 
         LcioFileNamer* m_namer;

--- a/include/LogManager.hh
+++ b/include/LogManager.hh
@@ -32,22 +32,22 @@ class LogManager: public Singleton<LogManager> {
 
     private:
 
-        // LogStream vector.
+        /** LogStream vector. */
         typedef std::vector<LogStream*> LogList;
 
-        // LogStream vector iterator.
+        /** LogStream vector iterator. */
         typedef LogList::iterator LogListIterator;
 
-        // LogMessenger vector.
+        /** LogMessenger vector. */
         typedef std::vector<LogMessenger*> LogMessengerList;
 
-        // LogMessenger vector iterator.
+        /** LogMessenger vector iterator. */
         typedef LogMessengerList::iterator LogMessengerListIterator;
 
-        // Name to LogStream map.
+        /** Name to LogStream map. */
         typedef std::map<std::string, LogStream*> LogNameMap;
 
-        // LogMessenger to LogStream map.
+        /** LogMessenger to LogStream map. */
         typedef std::map<LogStream*, LogMessenger*> LogMessengerMap;
 
     public:

--- a/include/PluginManager.hh
+++ b/include/PluginManager.hh
@@ -102,12 +102,11 @@ class PluginManager {
         void generatePrimary(G4Event* anEvent);
 
         /**
-         *
-         * Activate the track classification hook of registered plugins.
-         * @param aTrack The Geant4 track.
-         *
          * @brief Return a track classification from the user plugins that have stacking actions.
+         * Activate the track classification hook of registered plugins.
          *
+         * @param aTrack The Geant4 track.
+         * 
          * @note
          * The current classification will only be updated if a plugin actually provides a different classification
          * than the current one.

--- a/include/PluginManagerAccessor.hh
+++ b/include/PluginManagerAccessor.hh
@@ -41,7 +41,7 @@ class PluginManagerAccessor {
 
     protected:
 
-        /* The plugin manager pointer; allow protected access for convenience of sub-classes. */
+        /** The plugin manager pointer; allow protected access for convenience of sub-classes. */
         PluginManager* m_pluginManager;
 };
 

--- a/include/SlicApplication.hh
+++ b/include/SlicApplication.hh
@@ -211,31 +211,31 @@ class SlicApplication: public Singleton<SlicApplication>, public Module {
 
     protected:
 
-        // G4 UI manager.
+        /** G4 UI manager. */
         G4UIExecutive* m_ui;
 
-        // app messenger
+        /** app messenger */
         SlicApplicationMessenger* m_appMessenger;
 
-        // field messenger
+        /** field messenger */
         FieldMessenger* m_fieldMessenger;
 
         RunManager* m_runManager;
 
-        // application run mode: batch or interactive
+        /** application run mode: batch or interactive */
         ERunMode m_mode;
 
-        // return code
+        /** return code */
         int m_returnCode;
 
-        // Has the initialize() function been called?
+        /** Has the initialize() function been called? */
         bool m_isInitialized;
 
-        // What was the name of the SLIC binary from CL? (used by LcioFileNamer)
+        /** What was the name of the SLIC binary from CL? (used by LcioFileNamer) */
         std::string m_binaryname;
         std::string m_binarybasename;
 
-        // Version string of Geant4.
+        /** Version string of Geant4. */
         std::string* m_geant4VersionString;
 };
 }

--- a/include/TimeUtil.hh
+++ b/include/TimeUtil.hh
@@ -27,7 +27,7 @@ class TimeUtil {
             return s;
         }
 
-        // FIXME: This has only millisecond accuracy.
+        //! \todo FIXME: This has only millisecond accuracy.
         static long64 getTimeNS() {
             long64 t_sec = (long64) time(NULL);
             long64 t_ns = t_sec * ((long64) 1e9);

--- a/include/UserTrackInformation.hh
+++ b/include/UserTrackInformation.hh
@@ -62,8 +62,8 @@ class UserTrackInformation: public VUserTrackInformation {
 
         /**
          * Print out the track information.
+         * \todo Implement this method.
          */
-        // TODO: Implement this method.
         void Print() const {
             G4cout << "UserTrackInformation::Print is not implemented!!!" << G4endl;
         }

--- a/slic.cc
+++ b/slic.cc
@@ -1,5 +1,5 @@
 /*!
-  * @mainpage Simulator for the Linear Collider (SLIC) Documentation
+  * @mainpage Simulator for the Linear Collider (SLIC)
   *
   * @par
   * The SLIC simulator is a Geant4 package that uses LCDD as its geometry input.
@@ -17,10 +17,67 @@
   * <a href="https://confluence.slac.stanford.edu/display/ilc/SLIC">Confluence Wiki page</a>.
   *
   * @par
-  * Any questions can be directed to <a href="mailto:jeremym@slac.stanford.edu">Jeremy McCormick</a>
-  * or posted in the <a href="http://forum.linearcollider.org/index.php?t=threadt&frm_id=7&rid=0&S=012b8714798313e7abf7c4d092eb9d0a">Full Simulations Area</a>
-  * of the <a href="http://forum.linearcollider.org/">LinearCollider.org Forum</a>.
+  * Any questions can be directed to <a href="mailto:jeremym@slac.stanford.edu">Jeremy McCormick</a> or <a href="mailto:norman.graf@slac.stanford.edu">Norman Graf</a>.
+  * 
+  * @section installation Installation
+  * 
+  * SLIC is a C++ application that is built using the standard GCC compiler toolchain and the CMake build generation system.
+  * 
+  * @subsection req-tools Required Tools
+  * 
+  * - Recent gcc compiler toolchain (tested with GCC 7 on CentOS7)
+  *   - You cannot use the default gcc on RHE6 or a similarly old distribution, so you would need to install one yourself or use a dev toolset.
+  *   - The build is not compatible with gcc 4.8.5 now due to Geant4 updates.
+  * - CMake 3.8 or greater due to requirements of the Geant4 build system (tested with 3.17)
+  * 
+  * @subsection build Build Instructions
+  * 
+  * Start by cloning the project to a local directory.
+  * ```
+  * mkdir /scratch && cd /scratch
+  * git clone https://github.com/slaclab/slic
+  * ```
+  *
+  * Create the build directory within your slic project directory:
+  * ```
+  * mkdir build && build
+  * ```
+  *
+  * The SLIC build system is able to download and install all dependencies for the project if they are not found on your system.
+  * This requires a multi-step build for the dependencies to first be downloaded and installed before SLIC itself is built.
+  *
+  * From the build dir created above execute the following:
+  * ```
+  * cmake ..
+  * ```
+  * You should see a number of messages printed that indicate dependencies were not found and will be built.
+  *
+  * There are a few cmake options that can be used for configuring SLIC:
+  *
+  * | Variable             | Default Value              | Description                           | Notes                   |
+  * | -------------------- | ---------------------------| ------------------------------------- | ----------------------- |
+  * | WITH_GEANT4_UIVIS    | NO                         | Enable Geant4 visualization and UI    | Requires X11 and Qt     |
+  * | WITH_GEANT4_VERSION  | 10.6.1                     | Geant4 release tag to use             | `master` is not allowed |
+  * | CMAKE_INSTALL_PREFIX | ${CMAKE_BUILD_DIR}/install | Installation prefix for slic and deps | |
+  *
+  * Here is an example of all these options being used together:
+  * ```
+  * cmake -DWITH_GEANT4_UIVIS=ON -DWITH_GEANT4_VERSION=10.6.1 -DCMAKE_INSTALL_PREFIX=/work
+  * ```
+  * These options should be passed the first time you execute the `cmake` command when building the application.
+  *
+  * Now to the dependencies and SLIC, execute the following:
+  * ```
+  * make
+  * ```
+  * Now, you should be ready to install slic if the above completed without errors:
+  * ```
+  * make install
+  * ```
+  * 
+  * For further information see <a href="https://github.com/slaclab/slic/blob/master/README.md">SLIC README</a> on github.
   */
+
 // SLIC
 #include "SlicMain.hh"
 


### PR DESCRIPTION
I adjusted the Doxyfile to no longer display inline sources in the documentation (it doesn't work properly and adds no information). In addition to that, I corrected the style of some of the comments to be parseable by Doxygen. Last but not least, I adjusted the text displayed on the Doxygen main page which is the block of text added to the slic.cc file. This text now contains updated contact information and I added the installation guide as well. All of these changes do not affect the functionality of the code.